### PR TITLE
Add pinnedCertificates to FetchOptions

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -13,7 +13,7 @@ export type FetchOptions = {
   /** @default true */
   followRedirect?: boolean
 
-  /** for certificate pinning (ex. Signal) */
+  /** DER encoded certificate for certificate pinning (ex. Signal) */
   pinnedCertificates?: Buffer[]
 }
 


### PR DESCRIPTION
Add support for pinned certificates in FetchOptions for platforms like Signal.
We still need to implement this in the relevant libraries (swift/rust-fetch)

We're currently setting `NODE_TLS_REJECT_UNAUTHORIZED` in platform-signal which isn't ideal.