### PR TITLE
PersistentWS: allow more control over retries

### DIFF
--- a/src/PersistentWS.ts
+++ b/src/PersistentWS.ts
@@ -26,7 +26,7 @@ export default class PersistentWS {
     private readonly getConnectionInfo: () => Awaitable<{ endpoint: string, options?: WebSocket.ClientOptions }>,
     private readonly onMessage: (msg: Buffer) => void,
     private readonly onOpen?: () => void,
-    private readonly onClose?: (code?: number) => { retry: boolean },
+    private readonly onClose?: (code?: number) => { retry: boolean } | void,
   ) { }
 
   readonly connect = async () => {


### PR DESCRIPTION
> Let `onClose` return an object indicating whether it's OK to retry. This lets platforms stop the reconnection loop whenever appropriate (e.g. if the provided credentials are invalid - reconnecting doesn't help us there).
> 
> Also add a `disconnect` method that tries to close the underlying WebSocket with a certain code, but still dispatches `onClose` to let upstream consumers decide whether to reconnect or not. This is useful if some server state is tied to the lifecycle of the WebSocket itself, and we need to simply reconnect.

also adding detailed docs to the methods, since i think the websocket connection state machine goes deep (burned a few hours debugging) and this might help someone later.