### PR TITLE
PersistentWS: extend retry control to errors

### DIFF
--- a/src/PersistentWS.ts
+++ b/src/PersistentWS.ts
@@ -27,6 +27,7 @@ export default class PersistentWS {
     private readonly onMessage: (msg: Buffer) => void,
     private readonly onOpen?: () => void,
     private readonly onClose?: (code?: number) => { retry: boolean } | void,
+    private readonly onError?: (error: Error) => { retry: boolean } | void,
   ) { }
 
   readonly connect = async () => {
@@ -81,7 +82,9 @@ export default class PersistentWS {
       .on('error', error => {
         console.error('[PersistentWS] error', error)
         if (this.disposing) this.disposing = false
-        else retry()
+        else if (this.onError?.(error)?.retry ?? true) {
+          retry()
+        }
       })
   }
 


### PR DESCRIPTION
This just extends the addition of flexible retry control by @slice to an `onError` function. When a user disconnects or is unauthenticated, the server sends back 1006. Only on re-connection does it indicate that we need to re-authenticate (403). This'll allow us to handle this case.