### PR TITLE
PersistentWS: Always hit onError event regardless of disposing state

### DIFF
--- a/src/PersistentWS.ts
+++ b/src/PersistentWS.ts
@@ -81,10 +81,9 @@ export default class PersistentWS {
       })
       .on('error', error => {
         console.error('[PersistentWS] error', error)
+        const shouldRetry = this.onError?.(error)?.retry ?? true
         if (this.disposing) this.disposing = false
-        else if (this.onError?.(error)?.retry ?? true) {
-          retry()
-        }
+        else if (shouldRetry) retry()
       })
   }
 


### PR DESCRIPTION
But does not change the situation in which `retry()` is called. This just allows the caller to change state depending on the error regardless of the disposing state.