### PR TITLE
PersistentWS: add force disconnect method

### DIFF
--- a/src/PersistentWS.ts
+++ b/src/PersistentWS.ts
@@ -36,7 +36,13 @@ export default class PersistentWS {
     } catch (err) {
       texts.error('[PersistentWS] connect dispose error', err)
     }
-    const retry = debounce(() => { // this debounce may be unnecessary
+
+    // 'error' and 'close' can be dispatched in tandem under certain
+    // circumstances[1]; guard our retry logic behind a debounce to prevent
+    // introducing two conflicting reconnection "threads".
+    //
+    // [1]: https://github.com/websockets/ws/blob/5e42cfdc5fa114659908eaad4d9ead7d5051d740/lib/websocket.js#L1031
+    const retry = debounce(() => {
       if (++this.retryAttempt <= MAX_RETRY_ATTEMPTS) {
         const retryAfter = getRetryTimeout(this.retryAttempt)
         texts.log('[PersistentWS] will retry after', retryAfter, 'ms')


### PR DESCRIPTION
in a lot of situations where we call `PersistentWS#disconnect(…)`, we don't actually care about sending a close frame and waiting for the server's acknowledgement (which _will_ stall for 30 seconds if the underlying connection is already dead). add a `forceDisconnect` (name bikesheddable; `ws` calls it `terminate`) method that immediately closes.

i think we should encourage `forceDisconnect` over `disconnect` unless we care about disconnecting cleanly. i don't think it's obvious that `disconnect` can take 30 seconds until `onClose` is called.

i folded a lot of documentation changes into this PR to further clarify the operating semantics and state machine arrows at play