### PR TITLE
Prepare for upcoming onboarding redesign

### DIFF
--- a/src/PlatformInfo.ts
+++ b/src/PlatformInfo.ts
@@ -58,13 +58,16 @@ export type Pref = {
   default: boolean | string
 }
 
+type HTMLSVG = `<svg ${string} </svg>`
+type HexColor = `#${string}`
+
 export interface PlatformBrand {
   /** HTML of an SVG, or a Color */
-  background: string
+  background: HTMLSVG | HexColor
   /** HTML of an SVG (Monochrome) */
-  icon: string
+  icon: HTMLSVG
   /** HTML of an SVG (Colorful) */
-  coloredIcon?: string
+  coloredIcon?: HTMLSVG
 }
 
 export interface OverridablePlatformInfo {


### PR DESCRIPTION
This PR adds support for new type of icons in preparation for the upcoming onboarding redesign.

The idea is to pass a background SVG a foreground SVG, and a "mono" SVG.

![image](https://github.com/TextsHQ/platform-sdk/assets/9381261/039ecd9c-69b3-4bff-9d2b-c5809648f881)

The reason background is an SVG and not a color is because — while a color would work for Slack — it wouldn't work for Messenger, Instagram, and any other icon using gradients. We could have a specific type for color vs gradient, but it would likely just add complexity to the front end and reduce capabilities with Platform icons. Using an SVG allows for both unique colors as well as gradient to be supported.

![image](https://github.com/TextsHQ/platform-sdk/assets/9381261/560f13bd-a904-4fa3-8761-1e5614454f5f)

All adaptive icon SVGs can be exported in 48 x 48. The background size would be adapted directly when applied on the component, preserving the gradient aspect, and adapting the size no matter the display/window size.