### PR TITLE
[DESK-127] Add End 2 End Encrypted flag to Thread

### DIFF
--- a/src/Thread.ts
+++ b/src/Thread.ts
@@ -37,4 +37,6 @@ export interface Thread extends Identifiable, ExtraProp, OriginalProp {
 
   messages: Paginated<Message>
   participants: Paginated<Participant>
+
+  isE2EE?: boolean;
 }


### PR DESCRIPTION
For now this is required to know if a thread should decrypt media or not. There might be other use cases. Matrix rooms have a state event  `m.room.encryption` and I want to map this to the thread to use later on

```
      case 'm.room.encryption': {
        const thread = platformDatabase.getThread(event.room_id)
        if (!thread) break

        await platformDatabase.upsertThread(event.room_id, thread, {
          isEncrypted: true,
        }).sync()

        break
      }
```