### PR TITLE
[DESK-159] Extent removeReaction to include id and optional message id

### DIFF
--- a/src/Message.ts
+++ b/src/Message.ts
@@ -17,6 +17,7 @@ export interface MessageReaction extends Identifiable {
   participantID: UserID
   /** is the `reactionKey` an emoji */
   emoji?: boolean
+  messageID?: string
 }
 
 export type ThreadTitleUpdatedAction = { type: MessageActionType.THREAD_TITLE_UPDATED, title: string, actorParticipantID: UserID }

--- a/src/PlatformAPI.ts
+++ b/src/PlatformAPI.ts
@@ -185,7 +185,7 @@ export interface PlatformAPI {
   sendReadReceipt: (threadID: ThreadID, messageID?: MessageID, messageCursor?: string) => Awaitable<void>
 
   addReaction?: (threadID: ThreadID, messageID: MessageID, reactionKey: string) => Awaitable<void>
-  removeReaction?: (threadID: ThreadID, messageID: MessageID, reactionKey: string) => Awaitable<void>
+  removeReaction?: (threadID: ThreadID, messageID: MessageID, reactionKey: string, id: string, messageId?: string) => Awaitable<void>
 
   getLinkPreview?: (link: string) => Awaitable<MessageLink | undefined>
 

--- a/src/PlatformAPI.ts
+++ b/src/PlatformAPI.ts
@@ -185,7 +185,7 @@ export interface PlatformAPI {
   sendReadReceipt: (threadID: ThreadID, messageID?: MessageID, messageCursor?: string) => Awaitable<void>
 
   addReaction?: (threadID: ThreadID, messageID: MessageID, reactionKey: string) => Awaitable<void>
-  removeReaction?: (threadID: ThreadID, parentMessageID: MessageID, reactionKey: string, id: string, messageID?: string) => Awaitable<void>
+  removeReaction?: (threadID: ThreadID, parentMessageID: MessageID, reactionKey: string, reactionID?: string, messageID?: string) => Awaitable<void>
 
   getLinkPreview?: (link: string) => Awaitable<MessageLink | undefined>
 

--- a/src/PlatformAPI.ts
+++ b/src/PlatformAPI.ts
@@ -185,7 +185,7 @@ export interface PlatformAPI {
   sendReadReceipt: (threadID: ThreadID, messageID?: MessageID, messageCursor?: string) => Awaitable<void>
 
   addReaction?: (threadID: ThreadID, messageID: MessageID, reactionKey: string) => Awaitable<void>
-  removeReaction?: (threadID: ThreadID, messageID: MessageID, reactionKey: string, id: string, messageId?: string) => Awaitable<void>
+  removeReaction?: (threadID: ThreadID, parentMessageID: MessageID, reactionKey: string, id: string, messageID?: string) => Awaitable<void>
 
   getLinkPreview?: (link: string) => Awaitable<MessageLink | undefined>
 


### PR DESCRIPTION
I think this is required for Beeper reactions because we can't get the individual reaction with the `reactionKey` and `threadID`