### PR TITLE
[DESK-3395] Extend BrowserWindowProps to include headerWatcher to capure all headers when a url is requested

### DIFF
--- a/src/PlatformInfo.ts
+++ b/src/PlatformInfo.ts
@@ -1,6 +1,6 @@
 import type { CookieJar } from 'tough-cookie'
 import type { MessageDeletionMode, Attribute } from './enums'
-import type { ExtraProp } from './generic'
+import type { ExtraProp, StringWithAutocompleteOptions } from './generic'
 import type { NotificationsInfo } from './Notifications'
 import type { Participant } from './User'
 
@@ -31,6 +31,11 @@ export type BrowserWindowProps = {
   cookieDomains?: string[]
 
   isHidden?: boolean
+
+  headerWatcher?: {
+    url: string
+    header: StringWithAutocompleteOptions<'*'>
+  }
 }
 
 export type BrowserLogin = {

--- a/src/TextsGlobals.ts
+++ b/src/TextsGlobals.ts
@@ -47,6 +47,7 @@ export interface TextsNodeGlobals extends TextsGlobalsCommon {
     lastURL: string
     cookieJar: CookieJar.Serialized
     jsCodeResult?: any
+    headers?: Record<string, string> | string
   }>
 
   fetch: FetchFunction

--- a/src/generic.ts
+++ b/src/generic.ts
@@ -50,3 +50,5 @@ export type Button = {
   label: string
   linkURL: string
 }
+
+export type StringWithAutocompleteOptions<TOptions extends string> = | (string & {}) | TOptions


### PR DESCRIPTION
Implements changes in https://github.com/beeper/beeper-desktop-new/pull/1223 to extend `BrowserWindowProps` and `ReturnType<openBrowserWindow>`

* Adds `headerWatcher?: { url: string header: StringWithAutocompleteOptions<'*'> }` to `BrowserWindowProps` for when the browser window hits a URL and returns all headers or a named value of a header
* The result of `openBrowserWindow` can now return these headers/header
* Not sure the best to convey `*` is all headers. It should be in the autocomplete now to make it a little more obvious